### PR TITLE
Add support for assistive technologies

### DIFF
--- a/source/Components/Alerts/b-alert-header.html
+++ b/source/Components/Alerts/b-alert-header.html
@@ -1,4 +1,4 @@
-<div class="alert alert-${1|primary,secondary,success,danger,warning,info,light,dark|}">
+<div class="alert alert-${1|primary,secondary,success,danger,warning,info,light,dark|}" role="alert">
     <h4 class="alert-heading">${2:Header}</h4>
     ${3:Content}
 </div>

--- a/source/Components/Alerts/b-alert.html
+++ b/source/Components/Alerts/b-alert.html
@@ -1,3 +1,3 @@
-<div class="alert alert-${1|primary,secondary,success,danger,warning,info,light,dark|}">
+<div class="alert alert-${1|primary,secondary,success,danger,warning,info,light,dark|}" role="alert">
     ${2:Content}
 </div>

--- a/source/Components/Breadcrumb/b-breadcrumb.html
+++ b/source/Components/Breadcrumb/b-breadcrumb.html
@@ -1,5 +1,6 @@
-<nav>
+<nav aria-label="${1:Page breadcrumb}">
     <ol class="breadcrumb">
-        <li class="breadcrumb-item active">${1:Text}</li>$0
+        <li class="breadcrumb-item active" aria-current="page">${2:Item 1}</li>
+        <li class="breadcrumb-item">${3:Item 2}</li>$0
     </ol>
 </nav>

--- a/source/Components/Button group/b-btn-group-vertical.html
+++ b/source/Components/Button group/b-btn-group-vertical.html
@@ -1,3 +1,3 @@
-<div class="btn-group-vertical">
+<div class="btn-group-vertical" role="group" aria-label="${1:Vertical button group}">
     $0
 </div>

--- a/source/Components/Button group/b-btn-group.html
+++ b/source/Components/Button group/b-btn-group.html
@@ -1,3 +1,3 @@
-<div class="btn-group">
+<div class="btn-group" role="group" aria-label="${1:Button group}">
     $0
 </div>

--- a/source/Components/Carousel/b-carousel-controls.html
+++ b/source/Components/Carousel/b-carousel-controls.html
@@ -1,17 +1,19 @@
 <div id="${1:my-carousel}" class="carousel slide" data-ride="carousel">
     <div class="carousel-inner">
         <div class="carousel-item active">
-            <img class="d-block w-100" src="$4">
+            <img class="d-block w-100" src="$2" alt="${3:Carousel image alternate text}">
             <div class="carousel-caption d-none d-md-block">
-                <h5>${2:Title}</h5>
-                <p>${3:Text}</p>
+                <h5>${4:Title}</h5>
+                <p>${5:Text}</p>
             </div>
         </div>$0
     </div>
-    <a class="carousel-control-prev" href="#$1" data-slide="prev">
-        <span class="carousel-control-prev-icon"></span>
+    <a class="carousel-control-prev" href="#$1" data-slide="prev" role="button">
+        <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+        <span class="sr-only">${6:Previous}</span>
     </a>
-    <a class="carousel-control-next" href="#$1" data-slide="next">
-        <span class="carousel-control-next-icon"></span>
+    <a class="carousel-control-next" href="#$1" data-slide="next" role="button">
+        <span class="carousel-control-next-icon" aria-hidden="true"></span>
+        <span class="sr-only">${7:Next}</span>
     </a>
 </div>

--- a/source/Components/Carousel/b-carousel-full.html
+++ b/source/Components/Carousel/b-carousel-full.html
@@ -1,20 +1,30 @@
 <div id="${1:my-carousel}" class="carousel slide" data-ride="carousel">
     <ol class="carousel-indicators">
-        <li class="active" data-target="#$1" data-slide-to="0"></li>
+        <li data-target="#$1" data-slide-to="0" aria-current="location" class="active"></li>
+        <li data-target="#$1" data-slide-to="1"></li>
     </ol>
     <div class="carousel-inner">
         <div class="carousel-item active">
-            <img class="d-block w-100" src="$4">
+            <img class="d-block w-100" src="$2" alt="${3:Carousel image alternate text}">
             <div class="carousel-caption d-none d-md-block">
-                <h5>${2:Title}</h5>
-                <p>${3:Text}</p>
+                <h5>${4:Title}</h5>
+                <p>${5:Text}</p>
+            </div>
+        </div>
+        <div class="carousel-item">
+            <img class="d-block w-100" src="$6" alt="${7:Carousel image alternate text}">
+            <div class="carousel-caption d-none d-md-block">
+                <h5>${8:Title}</h5>
+                <p>${9:Text}</p>
             </div>
         </div>$0
     </div>
-    <a class="carousel-control-prev" href="#$1" data-slide="prev">
-        <span class="carousel-control-prev-icon"></span>
+    <a class="carousel-control-prev" href="#$1" data-slide="prev" role="button">
+        <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+        <span class="sr-only">${10:Previous}</span>
     </a>
-    <a class="carousel-control-next" href="#$1" data-slide="next">
-        <span class="carousel-control-next-icon"></span>
+    <a class="carousel-control-next" href="#$1" data-slide="next" role="button">
+        <span class="carousel-control-next-icon" aria-hidden="true"></span>
+        <span class="sr-only">${11:Next}</span>
     </a>
 </div>

--- a/source/Components/Carousel/b-carousel-indicators.html
+++ b/source/Components/Carousel/b-carousel-indicators.html
@@ -1,13 +1,21 @@
 <div id="${1:my-carousel}" class="carousel slide" data-ride="carousel">
     <ol class="carousel-indicators">
-        <li class="active" data-target="#$1" data-slide-to="0"></li>
+        <li data-target="#$1" data-slide-to="0" aria-current="location" class="active"></li>
+        <li data-target="#$1" data-slide-to="1"></li>
     </ol>
     <div class="carousel-inner">
         <div class="carousel-item active">
-            <img class="d-block w-100" src="$4">
+            <img class="d-block w-100" src="$2" alt="${3:Carousel image alternate text}">
             <div class="carousel-caption d-none d-md-block">
-                <h5>${2:Title}</h5>
-                <p>${3:Text}</p>
+                <h5>${4:Title}</h5>
+                <p>${5:Text}</p>
+            </div>
+        </div>
+        <div class="carousel-item">
+            <img class="d-block w-100" src="$6" alt="${7:Carousel image alternate text}">
+            <div class="carousel-caption d-none d-md-block">
+                <h5>${8:Title}</h5>
+                <p>${9:Text}</p>
             </div>
         </div>$0
     </div>

--- a/source/Components/Collapse/b-collapse.html
+++ b/source/Components/Collapse/b-collapse.html
@@ -1,4 +1,4 @@
-<button class="btn btn-${2|primary,secondary,success,danger,warning,info,light,dark,link|}" data-target="#${1:my-collapse}" data-toggle="collapse">${3:Text}</button>
+<button class="btn btn-${2|primary,secondary,success,danger,warning,info,light,dark,link|}" data-target="#${1:my-collapse}" data-toggle="collapse" aria-expanded="false" aria-controls="$1">${3:Text}</button>
 <div id="$1" class="collapse">
     $0
 </div>

--- a/source/Components/Dropdown/b-dropdown-menu.html
+++ b/source/Components/Dropdown/b-dropdown-menu.html
@@ -1,3 +1,3 @@
-<div class="dropdown-menu">
+<div class="dropdown-menu" aria-labelledby="${2:my-dropdown-button-id}">
     <a class="dropdown-item active" href="#">${1:Text}</a>$0
 </div>

--- a/source/Components/Dropdown/b-dropdown-split.html
+++ b/source/Components/Dropdown/b-dropdown-split.html
@@ -1,7 +1,9 @@
 <div class="btn-group ${1|dropdown,dropup,dropright,dropleft|}">
     <button class="btn btn-${2|primary,secondary,success,danger,warning,info,light,dark,link|}">${3:Text}</button>
-    <button class="btn btn-$2 dropdown-toggle dropdown-toggle-split" data-toggle="dropdown"></button>
-    <div class="dropdown-menu">
+    <button class="btn btn-$2 dropdown-toggle dropdown-toggle-split" id="${5:my-dropdown-button-id}" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+        <span class="sr-only">Toggle Dropdown</span>
+    </button>
+    <div class="dropdown-menu" aria-labelledby="$5">
         <a class="dropdown-item active" href="#">${4:Text}</a>$0
     </div>
 </div>

--- a/source/Components/Dropdown/b-dropdown.html
+++ b/source/Components/Dropdown/b-dropdown.html
@@ -1,6 +1,6 @@
 <div class="${1|dropdown,dropup,dropright,dropleft|}">
-    <button class="btn btn-${2|primary,secondary,success,danger,warning,info,light,dark,link|} dropdown-toggle" data-toggle="dropdown">${3:Text}</button>
-    <div class="dropdown-menu">
+    <button class="btn btn-${2|primary,secondary,success,danger,warning,info,light,dark,link|} dropdown-toggle" id="${5:my-dropdown-button-id}" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">${3:Text}</button>
+    <div class="dropdown-menu" aria-labelledby="$5">
         <a class="dropdown-item active" href="#">${4:Text}</a>$0
     </div>
 </div>

--- a/source/Components/Input group/b-input-group-append.html
+++ b/source/Components/Input group/b-input-group-append.html
@@ -1,6 +1,6 @@
 <div class="input-group">
-    <input class="form-control" type="${1|text,number,email,password|}">
+    <input class="form-control" type="${1|text,number,email,password|}" placeholder="${4:Recipient's $1}" aria-label="$4" aria-describedby="$3">
     <div class="input-group-append">
-        <span class="input-group-text">${2:Text}</span>
+        <span class="input-group-text" id="${3:my-addon-id}">${2:Text}</span>
     </div>
 </div>

--- a/source/Components/Input group/b-input-group-full.html
+++ b/source/Components/Input group/b-input-group-full.html
@@ -2,7 +2,7 @@
     <div class="input-group-prepend">
         <span class="input-group-text">${2:Text}</span>
     </div>
-    <input class="form-control" type="${1|text,number,email,password|}">
+    <input class="form-control" type="${1|text,number,email,password|}" aria-label="Recipient's $1">
     <div class="input-group-append">
         <span class="input-group-text">${3:Text}</span>
     </div>

--- a/source/Components/Input group/b-input-group-prepend.html
+++ b/source/Components/Input group/b-input-group-prepend.html
@@ -1,6 +1,6 @@
 <div class="input-group">
     <div class="input-group-prepend">
-        <span class="input-group-text">${2:Text}</span>
+        <span class="input-group-text" id="${3:my-addon-id}">${2:Text}</span>
     </div>
-    <input class="form-control" type="${1|text,number,email,password|}">
+    <input class="form-control" type="${1|text,number,email,password|}" aria-label="Recipient's $1" aria-describedby="$3">
 </div>

--- a/source/Components/List group/b-list-group-action-flush.html
+++ b/source/Components/List group/b-list-group-action-flush.html
@@ -1,3 +1,4 @@
 <ul class="list-group list-group-flush">
-    <a class="list-group-item list-group-item-action active" href="#">${1:Text}</a>$0
+    <a class="list-group-item list-group-item-action active" href="#">${1:Text}</a>
+    <a class="list-group-item list-group-item-action disabled" href="#" tabindex="-1" aria-disabled="true">${2:Disabled item}</a>$0
 </ul>

--- a/source/Components/List group/b-list-group-action.html
+++ b/source/Components/List group/b-list-group-action.html
@@ -1,3 +1,4 @@
 <ul class="list-group">
-    <a class="list-group-item list-group-item-action active" href="#">${1:Text}</a>$0
+    <a class="list-group-item list-group-item-action active" href="#">${1:Text}</a>
+    <a class="list-group-item list-group-item-action disabled" href="#" tabindex="-1" aria-disabled="true">${2:Disabled item}</a>$0
 </ul>

--- a/source/Components/List group/b-list-group-flush.html
+++ b/source/Components/List group/b-list-group-flush.html
@@ -1,3 +1,4 @@
 <ul class="list-group list-group-flush">
-    <li class="list-group-item active">${1:Text}</li>$0
+    <li class="list-group-item active">${1:Text}</li>
+    <li class="list-group-item disabled" aria-disabled="true">${2:Disabled item}</li>$0
 </ul>

--- a/source/Components/List group/b-list-group.html
+++ b/source/Components/List group/b-list-group.html
@@ -1,3 +1,4 @@
 <ul class="list-group">
-    <li class="list-group-item active">${1:Text}</li>$0
+    <li class="list-group-item active">${1:Text}</li>
+    <li class="list-group-item disabled" aria-disabled="true">${2:Disabled item}</li>$0
 </ul>

--- a/source/Components/Media object/b-media-left.html
+++ b/source/Components/Media object/b-media-left.html
@@ -1,7 +1,7 @@
 <div class="media">
-    <img class="align-self-${1|start,center,end|}" src="$4">
+    <img class="align-self-${1|start,center,end|}" alt="${3:Image alternate text}" src="$2">
     <div class="media-body">
-        <h5 class="mb-0">${2:Header}</h5>
-        ${3:Content}
+        <h5 class="mb-0">${4:Header}</h5>
+        ${5:Content}
     </div>
 </div>

--- a/source/Components/Media object/b-media-right.html
+++ b/source/Components/Media object/b-media-right.html
@@ -1,7 +1,7 @@
 <div class="media">
     <div class="media-body">
-        <h5 class="mb-0">${2:Header}</h5>
-        ${3:Content}
+        <h5 class="mb-0">${4:Header}</h5>
+        ${5:Content}
     </div>
-    <img class="align-self-${1|start,center,end|}" src="$4">
+    <img class="align-self-${1|start,center,end|}" alt="${3:Image alternate text}" src="$2">
 </div>

--- a/source/Components/Modal/b-modal-center.html
+++ b/source/Components/Modal/b-modal-center.html
@@ -1,5 +1,5 @@
-<div class="modal fade">
-    <div class="modal-dialog modal-dialog-centered">
+<div class="modal fade" tabindex="-1" role="dialog" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered" role="document">
         <div class="modal-content">
             <div class="modal-body">
                 <p>${1:Content}</p>$0

--- a/source/Components/Modal/b-modal-footer-center.html
+++ b/source/Components/Modal/b-modal-footer-center.html
@@ -1,5 +1,5 @@
-<div class="modal fade">
-    <div class="modal-dialog modal-dialog-centered">
+<div class="modal fade" tabindex="-1" role="dialog" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered" role="document">
         <div class="modal-content">
             <div class="modal-body">
                 <p>${1:Content}</p>$0

--- a/source/Components/Modal/b-modal-footer.html
+++ b/source/Components/Modal/b-modal-footer.html
@@ -1,5 +1,5 @@
-<div class="modal fade">
-    <div class="modal-dialog">
+<div class="modal fade" tabindex="-1" role="dialog" aria-hidden="true">
+    <div class="modal-dialog" role="document">
         <div class="modal-content">
             <div class="modal-body">
                 <p>${1:Content}</p>$0

--- a/source/Components/Modal/b-modal-full-center.html
+++ b/source/Components/Modal/b-modal-full-center.html
@@ -1,17 +1,17 @@
-<div class="modal fade">
-    <div class="modal-dialog modal-dialog-centered">
+<div class="modal fade" tabindex="-1" role="dialog" aria-labelledby="$2" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered" role="document">
         <div class="modal-content">
             <div class="modal-header">
-                <h5 class="modal-title">${1:Title}</h5>
-                <button class="close" data-dismiss="modal">
-                    <span>&times;</span>
+                <h5 class="modal-title" id="${2:my-modal-title-id}">${1:Title}</h5>
+                <button class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
                 </button>
             </div>
             <div class="modal-body">
-                <p>${2:Content}</p>$0
+                <p>${3:Content}</p>$0
             </div>
             <div class="modal-footer">
-                ${3:Footer}
+                ${4:Footer}
             </div>
         </div>
     </div>

--- a/source/Components/Modal/b-modal-full.html
+++ b/source/Components/Modal/b-modal-full.html
@@ -1,17 +1,17 @@
-<div class="modal fade">
-    <div class="modal-dialog">
+<div class="modal fade" tabindex="-1" role="dialog" aria-labelledby="$2" aria-hidden="true">
+    <div class="modal-dialog" role="document">
         <div class="modal-content">
             <div class="modal-header">
-                <h5 class="modal-title">${1:Title}</h5>
-                <button class="close" data-dismiss="modal">
-                    <span>&times;</span>
+                <h5 class="modal-title" id="${2:my-modal-title-id}">${1:Title}</h5>
+                <button class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
                 </button>
             </div>
             <div class="modal-body">
-                <p>${2:Content}</p>$0
+                <p>${3:Content}</p>$0
             </div>
             <div class="modal-footer">
-                ${3:Footer}
+                ${4:Footer}
             </div>
         </div>
     </div>

--- a/source/Components/Modal/b-modal-header-center.html
+++ b/source/Components/Modal/b-modal-header-center.html
@@ -1,14 +1,14 @@
-<div class="modal fade">
-    <div class="modal-dialog modal-dialog-centered">
+<div class="modal fade" tabindex="-1" role="dialog" aria-labelledby="$2" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered" role="document">
         <div class="modal-content">
             <div class="modal-header">
-                <h5 class="modal-title">${1:Title}</h5>
-                <button class="close" data-dismiss="modal">
-                    <span>&times;</span>
+                <h5 class="modal-title" id="${2:my-modal-title-id}">${1:Title}</h5>
+                <button class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
                 </button>
             </div>
             <div class="modal-body">
-                <p>${2:Content}</p>$0
+                <p>${3:Content}</p>$0
             </div>
         </div>
     </div>

--- a/source/Components/Modal/b-modal-header.html
+++ b/source/Components/Modal/b-modal-header.html
@@ -1,14 +1,14 @@
-<div class="modal fade">
-    <div class="modal-dialog">
+<div class="modal fade" tabindex="-1" role="dialog" aria-labelledby="$2" aria-hidden="true">
+    <div class="modal-dialog" role="document">
         <div class="modal-content">
             <div class="modal-header">
-                <h5 class="modal-title">${1:Title}</h5>
-                <button class="close" data-dismiss="modal">
-                    <span>&times;</span>
+                <h5 class="modal-title" id="${2:my-modal-title-id}">${1:Title}</h5>
+                <button class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
                 </button>
             </div>
             <div class="modal-body">
-                <p>${2:Content}</p>$0
+                <p>${3:Content}</p>$0
             </div>
         </div>
     </div>

--- a/source/Components/Modal/b-modal.html
+++ b/source/Components/Modal/b-modal.html
@@ -1,5 +1,5 @@
-<div class="modal fade">
-    <div class="modal-dialog">
+<div class="modal fade" tabindex="-1" role="dialog" aria-hidden="true">
+    <div class="modal-dialog" role="document">
         <div class="modal-content">
             <div class="modal-body">
                 <p>${1:Content}</p>$0

--- a/source/Components/Navbar/b-navbar.html
+++ b/source/Components/Navbar/b-navbar.html
@@ -1,12 +1,15 @@
 <nav class="navbar navbar-expand-lg navbar-${1|light,dark|} bg-$1 ${2|fixed-top,fixed-bottom,sticky-top|}">
-    <a class="navbar-brand">${4:Brand}</a>
-    <button class="navbar-toggler" data-target="#${3:my-nav}" data-toggle="collapse">
+    <a class="navbar-brand">${5:Brand}</a>
+    <button class="navbar-toggler" data-target="#${3:my-nav}" data-toggle="collapse" aria-controls="$3" aria-expanded="false" aria-label="${4:Toggle navigation}">
         <span class="navbar-toggler-icon"></span>
     </button>
     <div id="$3" class="collapse navbar-collapse">
         <ul class="navbar-nav mr-auto">
             <li class="nav-item active">
-                <a class="nav-link" href="#">${5:Text}</a>
+                <a class="nav-link" href="#">${6:Item 1} <span class="sr-only">(current)</span></a>
+            </li>
+            <li class="nav-item">
+                <a class="nav-link disabled" href="#" tabindex="-1" aria-disabled="true">${7:Item 2}</a>
             </li>$0
         </ul>
     </div>

--- a/source/Components/Navs/b-nav-fill.html
+++ b/source/Components/Navs/b-nav-fill.html
@@ -1,5 +1,8 @@
 <nav class="nav nav-fill">
     <li class="nav-item">
-        <a class="nav-link active" href="#">${1:Text}</a>
+        <a class="nav-link active" href="#">${1:Item 1}</a>
     </li>$0
+    <li class="nav-item">
+        <a class="nav-link disabled" href="#" tabindex="-1" aria-disabled="true">${2:Item 2}</a>
+    </li>
 </nav>

--- a/source/Components/Navs/b-nav-vertical.html
+++ b/source/Components/Navs/b-nav-vertical.html
@@ -1,5 +1,8 @@
 <nav class="nav flex-column">
     <li class="nav-item">
-        <a class="nav-link active" href="#">${1:Text}</a>
+        <a class="nav-link active" href="#">${1:Item 1}</a>
     </li>$0
+    <li class="nav-item">
+        <a class="nav-link disabled" href="#" tabindex="-1" aria-disabled="true">${2:Item 2}</a>
+    </li>
 </nav>

--- a/source/Components/Navs/b-nav.html
+++ b/source/Components/Navs/b-nav.html
@@ -1,5 +1,8 @@
 <nav class="nav">
     <li class="nav-item">
-        <a class="nav-link active" href="#">${1:Text}</a>
+        <a class="nav-link active" href="#">${1:Item 1}</a>
     </li>$0
+    <li class="nav-item">
+        <a class="nav-link disabled" href="#" tabindex="-1" aria-disabled="true">${2:Item 2}</a>
+    </li>
 </nav>

--- a/source/Components/Pagination/b-pagination.html
+++ b/source/Components/Pagination/b-pagination.html
@@ -1,7 +1,13 @@
-<nav>
+<nav aria-label="${1:Page navigation}">
     <ul class="pagination">
+        <li class="page-item active" aria-current="page">
+            <a class="page-link" href="#">${2:Page 1} <span class="sr-only">(current)</span></a>
+        </li>
+        <li class="page-item disabled">
+            <a class="page-link" href="#" tabindex="-1" aria-disabled="true">${3:Page 2}</a>
+        </li>
         <li class="page-item">
-            <a class="page-link" href="#">${1:Page 1}</a>
+            <a class="page-link" href="#">${4:Page 3}</a>
         </li>$0
     </ul>
 </nav>

--- a/source/Components/Progress/b-progress-striped.html
+++ b/source/Components/Progress/b-progress-striped.html
@@ -1,3 +1,3 @@
 <div class="progress">
-    <div class="progress-bar progress-bar-striped bg-primary" style="width: ${1:25}%">${2:Text}</div>
+    <div class="progress-bar progress-bar-striped bg-primary" style="width: ${1:25}%" role="progressbar" aria-valuenow="$1" aria-valuemin="0" aria-valuemax="100">${2:Text}</div>
 </div>

--- a/source/Components/Progress/b-progress.html
+++ b/source/Components/Progress/b-progress.html
@@ -1,3 +1,3 @@
 <div class="progress">
-    <div class="progress-bar bg-primary" style="width: ${1:25}%">${2:Text}</div>
+    <div class="progress-bar bg-primary" style="width: ${1:25}%" role="progressbar" aria-valuenow="$1" aria-valuemin="0" aria-valuemax="100">${2:Text}</div>
 </div>

--- a/source/Components/Spinners/b-spinner-growing.html
+++ b/source/Components/Spinners/b-spinner-growing.html
@@ -1,1 +1,3 @@
-<div class="spinner-grow text-${1|primary,secondary,success,danger,warning,info,light,dark|}"></div>
+<div class="spinner-grow text-${1|primary,secondary,success,danger,warning,info,light,dark|}" role="status">
+    <span class="sr-only">${2:Loading...}</span>
+</div>

--- a/source/Components/Spinners/b-spinner.html
+++ b/source/Components/Spinners/b-spinner.html
@@ -1,1 +1,3 @@
-<div class="spinner-border text-${1|primary,secondary,success,danger,warning,info,light,dark|}"></div>
+<div class="spinner-border text-${1|primary,secondary,success,danger,warning,info,light,dark|}" role="status">
+    <span class="sr-only">${2:Loading...}</span>
+</div>

--- a/source/Components/Toasts/b-toast.html
+++ b/source/Components/Toasts/b-toast.html
@@ -1,10 +1,10 @@
-<div class="toast">
+<div class="toast" role="alert" aria-live="assertive" aria-atomic="true">
     <div class="toast-header">
-        <img src="$1" class="rounded mr-2">
-        <strong class="mr-auto">${2:Title}</strong>
-        <small>${3:Note}</small>
-        <button type="button" class="ml-2 mb-1 close" data-dismiss="toast">
-            <span>&times;</span>
+        <img src="$1" class="rounded mr-2" alt="${2:Toast icon alternate text}">
+        <strong class="mr-auto">${3:Title}</strong>
+        <small>${4:Note}</small>
+        <button type="button" class="ml-2 mb-1 close" data-dismiss="toast" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
         </button>
     </div>
     <div class="toast-body">

--- a/source/Content/Figures/b-figure.html
+++ b/source/Content/Figures/b-figure.html
@@ -1,4 +1,4 @@
 <figure class="figure">
-    <img class="figure-img img-fluid" src="$2">
+    <img class="figure-img img-fluid" src="$2" alt="${3:Image alternate text}">
     <figcaption class="figure-caption">${1:Content}</figcaption>
 </figure>

--- a/source/Content/Images/b-img-fluid.html
+++ b/source/Content/Images/b-img-fluid.html
@@ -1,1 +1,1 @@
-<img class="img-fluid" src="$1">
+<img class="img-fluid" src="$1" alt="${2:Image alternate text}">

--- a/source/Content/Images/b-img-thumbnail.html
+++ b/source/Content/Images/b-img-thumbnail.html
@@ -1,1 +1,1 @@
-<img class="img-thumbnail" src="$1">
+<img class="img-thumbnail" src="$1" alt="${2:Image alternate text}">


### PR DESCRIPTION
This PR should solve part of the problem stated in [this issue](https://github.com/Zaczero/bootstrap-v4-snippets/issues/4) and more than 60k users will be encouraged to support assistive technologies.

With many attributes added to (once simple) snippets, the code might be harder to read. Although, it can be solved by providing pre-formatted snippets to users. 

So this long and some times ugly snippet:

``` html
<button class="btn btn-primary" type="button" data-toggle="popover" data-placement="top" data-trigger="focus" data-content="Content">Text</button>
```

Could be turned into this short and neat snippet:

``` html
<button class="btn btn-primary" 
        type="button" 
        data-toggle="popover" 
        data-placement="top" 
        data-trigger="focus" 
        data-content="Content">Text</button>
```